### PR TITLE
Mock actions intents webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ OPENAI_API_KEY="your-openai-api-key-here"
 # Next.js
 NEXTAUTH_SECRET="your-nextauth-secret-here"
 NEXTAUTH_URL="http://localhost:3000"
+
+WEBHOOK_URL="https://webhook.site/SOME_UNIQUE_VALUE"

--- a/src/pages/api/sessions/end.ts
+++ b/src/pages/api/sessions/end.ts
@@ -108,8 +108,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         console.log('soapData', soapData);
         for (const action of actions) {
           if (!action.type) continue; // skip invalid actions
+          // check if we have a url in the environment variable for webhook
+          const webhookUrl = process.env.WEBHOOK_URL;
+          if (!webhookUrl) {
+            console.error('No webhook URL found in environment variables');
+            continue;
+          }
           try {
-            const webhookResponse = await fetch('https://webhook.site/YOUR-UNIQUE-URL', { // just an example
+            const webhookResponse = await fetch(webhookUrl, { // just an example
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,7 +27,7 @@ interface SOAPSummary {
   assessment: string
   plan: string
   summary: string
-  action: string
+  actions: { type: string; details: string }[]
 }
 
 export default function MedicalTranslationApp() {
@@ -427,7 +427,20 @@ export default function MedicalTranslationApp() {
                   </div>
                   <div className="bg-gray-700 rounded-lg p-4">
                     <h4 className="font-medium text-orange-400 mb-2">Actions & Follow-up</h4>
-                    <p className="text-gray-300">{soapSummary.action}</p>
+                    {soapSummary.actions.length > 0 ? (
+                      <div className="space-y-2">
+                        {soapSummary.actions.map((action, index) => (
+                          <div key={index} className="flex items-start space-x-2">
+                            <span className="text-orange-400 text-sm font-medium min-w-0 flex-shrink-0">
+                              {action.type.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}:
+                            </span>
+                            <span className="text-gray-300 text-sm">{action.details}</span>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="text-gray-400 text-sm">No actions identified</p>
+                    )}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
This is just a demonstration of a way to detect intents and map them to actions, then, perform those actions.

For the purpose of this example, it's simple - it just asks the LLM to create a more structured response for actions so then we can iterate over them and broadcast them to a webhook.